### PR TITLE
Automatically detect CPU count

### DIFF
--- a/mop/management/commands/fit_all_events_PSPL.py
+++ b/mop/management/commands/fit_all_events_PSPL.py
@@ -8,6 +8,7 @@ import json
 import numpy as np
 import datetime
 import random
+import os
 
 class Command(BaseCommand):
 
@@ -16,6 +17,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
 
         parser.add_argument('events_to_fit', help='all, alive, need or [years]')
+        parser.add_argument('--cores', help='Number of workers to use', default=os.cpu_count(), type=int)
 
     
     def handle(self, *args, **options):
@@ -75,7 +77,7 @@ class Command(BaseCommand):
 
                    photometry = np.c_[time,phot]
 
-                   t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model = fittools.fit_PSPL_parallax(target.ra, target.dec, photometry,cores = 8)
+                   t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model = fittools.fit_PSPL_parallax(target.ra, target.dec, photometry, cores = options['cores'])
                    
                    #Add photometry model
                    

--- a/mop/management/commands/fit_event_PSPL.py
+++ b/mop/management/commands/fit_event_PSPL.py
@@ -9,6 +9,7 @@ from mop.brokers import gaia as gaia_mop
 import json
 import numpy as np
 import datetime
+import os
 
 class Command(BaseCommand):
 
@@ -16,6 +17,7 @@ class Command(BaseCommand):
     
     def add_arguments(self, parser):
         parser.add_argument('target_name', help='name of the event to fit')
+        parser.add_argument('--cores', help='Number of workers to use', default=os.cpu_count(), type=int)
 
     
     def handle(self, *args, **options):
@@ -46,7 +48,7 @@ class Command(BaseCommand):
 
         
 
-           t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model = fittools.fit_PSPL_parallax(target.ra, target.dec, photometry, cores = None)
+           t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model = fittools.fit_PSPL_parallax(target.ra, target.dec, photometry, cores = options['cores'])
 
            #Add photometry model
            


### PR DESCRIPTION
For the `dev` branch.

By default, these commands now automatically detect the CPU count and use them all. This way when we change machine sizes, we don't need to change the code. Implemented as a command line option, so that users can override this behavior without editing the code, to customize for their specific needs, if this default value doesn't work for them.

We might need to adjust the default to `2 * os.cpu_count()`, but only testing will tell. I think we should try it just like this. :smiley: