### PR TITLE
Helm chart core count plumbing

### DIFF
--- a/helm-chart/templates/cronjob-fitaliveevents.yaml
+++ b/helm-chart/templates/cronjob-fitaliveevents.yaml
@@ -37,6 +37,9 @@ spec:
                 - manage.py
                 - fit_all_events_PSPL
                 - alive
+                {{- with .Values.fitaliveevents.cores }}
+                - --cores={{ . }}
+                {{- end }}
               env:
                 {{- include "mop.backendEnv" . | nindent 16 }}
               resources:

--- a/helm-chart/templates/cronjob-fitneedevents.yaml
+++ b/helm-chart/templates/cronjob-fitneedevents.yaml
@@ -37,6 +37,9 @@ spec:
                 - manage.py
                 - fit_all_events_PSPL
                 - need
+                {{- with .Values.fitneedevents.cores }}
+                - --cores={{ . }}
+                {{- end }}
               env:
                 {{- include "mop.backendEnv" . | nindent 16 }}
               resources:

--- a/helm-chart/values-dev.yaml
+++ b/helm-chart/values-dev.yaml
@@ -53,23 +53,25 @@ ingress:
 # CronJob: Fit Alive Events
 fitaliveevents:
   enabled: true
+  cores: 4
   resources:
     requests:
-      cpu: 2
-      memory: 2048Mi
+      cpu: 3500m
+      memory: 1024Mi
     limits:
-      cpu: 4
+      cpu: 3500m
       memory: 4096Mi
 
 # CronJob: Fit Need Events
 fitneedevents:
   enabled: true
+  cores: 2
   resources:
     requests:
       cpu: 2
-      memory: 2048Mi
+      memory: 512Mi
     limits:
-      cpu: 4
+      cpu: 3500m
       memory: 4096Mi
 
 # CronJob: Run TAP


### PR DESCRIPTION
Hey again Etienne,

You merged my other PR just a few seconds before I added these changes. This plumbs the whole
thing through the helm chart for you, so we can control CPU count from our deployment configuration.

I also set the resource limits so they should work with our cluster and not overwhelm any other users.

Thanks,
Ira