### PR TITLE
Adaptations developed during deployment at NCSA

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: mop
 description: A Helm chart for Kubernetes for the MOP TOM
 
@@ -13,8 +13,14 @@ description: A Helm chart for Kubernetes for the MOP TOM
 type: application
 
 # This is the chart version. Don't change it. The helmPipeline() appends the git hash to it as needed.
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. Don't change it. This value
 # is edited by helmPipeline() to be consistent with the latest git-tag on the master branch of the repository.
 appVersion: 0.0.0
+
+dependencies:
+- name: postgresql
+  version: 8.6.4
+  repository: https://charts.helm.sh/stable
+  condition: useDockerizedDatabase

--- a/helm-chart/requirements.lock
+++ b/helm-chart/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 8.6.4
-digest: sha256:f2b56726d815fac0b860406a670a7cbb87544689a4f4ce259d998fb7858d6797
-generated: "2020-09-10T13:05:56.384525436-07:00"

--- a/helm-chart/requirements.yaml
+++ b/helm-chart/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-- name: postgresql
-  version: 8.6.4
-  repository: https://charts.helm.sh/stable
-  condition: useDockerizedDatabase

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -76,6 +76,8 @@ build it here and use it everywhere.
 {{- define "mop.backendEnv" -}}
 - name: PYTHONUNBUFFERED
   value: "1"
+- name: URL_BASE_PATH
+  value: {{ .Values.ingress.basePath | quote }}
 - name: DB_HOST
   value: {{ include "mop.dbhost" . | quote }}
 - name: DB_NAME

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -107,13 +107,38 @@ build it here and use it everywhere.
 - name: IRSA_USERNAME
   value: {{ .Values.irsaUsername | quote }}
 - name: IRSA_PASSWORD
-  value: {{ .Values.irsaPassword | quote }} 
+  value: {{ .Values.irsaPassword | quote }}
+{{- if .Values.awsExistingSecret }}
+- name: AWS_S3_ENDPOINT_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.awsExistingSecret | quote }}
+      key: "awsEndpointUrl"
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.awsExistingSecret | quote }}
+      key: "awsAccessKeyId"
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.awsExistingSecret | quote }}
+      key: "awsSecretAccessKey"
+- name: AWS_S3_BUCKET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.awsExistingSecret | quote }}
+      key: "awsS3Bucket"
+{{- else }}
+- name: AWS_S3_ENDPOINT_URL
+  value: {{ .Values.awsEndpointUrl | quote }}
 - name: AWS_ACCESS_KEY_ID
   value: {{ .Values.awsAccessKeyId | quote }}
 - name: AWS_SECRET_ACCESS_KEY
   value: {{ .Values.awsSecretAccessKey | quote }}
 - name: AWS_S3_BUCKET
-  value: {{ .Values.awsS3Bucket | quote }}  
+  value: {{ .Values.awsS3Bucket | quote }}
+{{- end }}
 - name: GEMINI_USERNAME
   value: {{ .Values.geminiUsername | quote }}
 - name: GEMINI_N_API_KEY

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
               readOnly: false
             - name: astropy
               mountPath: /.astropy
-              readonly: false
+              readOnly: false
         {{- end }}
         - name: django-collectstatic
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
@@ -102,7 +102,7 @@ spec:
               readOnly: false
             - name: astropy
               mountPath: /.astropy
-              readonly: false
+              readOnly: false
             - name: static
               mountPath: /static
               readOnly: false

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -130,11 +130,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /{{ .Values.ingress.basePath }}
               port: gunicorn
           readinessProbe:
             httpGet:
-              path: /
+              path: /{{ .Values.ingress.basePath }}
               port: gunicorn
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -205,7 +205,10 @@ lcoProposalId: ""
 lcoUsername: ""
 
 # AWS Credentials
-# These MUST be overriden in secret configuration file
+# If `awsExistingSecret` is specified, all `aws*` params must be included in the specified secret
+awsExistingSecret: ""
+# These MUST be overriden in secret configuration file if `awsExistingSecret` is not specified
+awsEndpointUrl: ""
 awsAccessKeyId: ""
 awsSecretAccessKey: ""
 awsS3Bucket: ""

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -142,6 +142,7 @@ service:
 
 ingress:
   enabled: false
+  basePath: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/mop/settings.py
+++ b/mop/settings.py
@@ -189,6 +189,7 @@ MEDIA_URL = '/data/'
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
+AWS_S3_ENDPOINT_URL = os.getenv('AWS_S3_ENDPOINT_URL', '')
 AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID', '')
 AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY', '')
 AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_S3_BUCKET', '')

--- a/mop/settings.py
+++ b/mop/settings.py
@@ -22,7 +22,11 @@ import tempfile
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-
+# Get URL base path
+base_path = os.environ.get('URL_BASE_PATH', '').strip('/')
+base_path_trailing_slash = ''
+if base_path:
+    base_path_trailing_slash = '/'
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
@@ -149,9 +153,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-LOGIN_URL = '/accounts/login/'
-LOGIN_REDIRECT_URL = '/'
-LOGOUT_REDIRECT_URL = '/'
+LOGIN_URL = f'/{base_path}{base_path_trailing_slash}accounts/login/'
+LOGIN_REDIRECT_URL = f'/{base_path}'
+LOGOUT_REDIRECT_URL = f'/{base_path}'
 
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',

--- a/mop/urls.py
+++ b/mop/urls.py
@@ -16,8 +16,17 @@ Including another URLconf
 from django.urls import path, include
 
 from mop.views import MOPTargetDetailView
+from django.views.generic import TemplateView
+import os
 
+base_path = os.environ.get('URL_BASE_PATH', '').strip('/')
+trailing_slash = ''
+if base_path:
+    trailing_slash = '/'
 urlpatterns = [
-    path('targets/<int:pk>/', MOPTargetDetailView.as_view(), name='detail'),
-    path('', include('tom_common.urls')),
+    path(f'''{base_path}{trailing_slash}targets/<int:pk>/''', MOPTargetDetailView.as_view(), name='detail'),
+    path(f'''{base_path}{trailing_slash}''', TemplateView.as_view(
+        template_name='tom_common/index.html',
+        extra_context={"base_path": base_path}), name='home'),
+    path(f'''{base_path}{trailing_slash}''', include('tom_common.urls')),
 ]

--- a/templates/tom_common/navbar_content.html
+++ b/templates/tom_common/navbar_content.html
@@ -5,7 +5,7 @@ For customization instructions, see tom_common/base.html
 {% endcomment %}
 
 <li class="nav-item {% if request.resolver_match.url_name == 'home' %}active{% endif %}">
-    <a class="nav-link" href="/">Home <span class="sr-only">(current)</span></a>
+    <a class="nav-link" href="/{{ base_path }}">Home <span class="sr-only">(current)</span></a>
 </li>
 
 <li class="nav-item dropdown">


### PR DESCRIPTION
The adapations in this pull request include support for a non-root base path (e.g. `example.com/mop`) as well as support for non-AWS S3 bucket URLs (e.g. self-hosted MinIO S3 buckets). It also makes trivial updates to the Helm chart apiVersion from v1 to v2, pulling the dependent chart into the `Chart.yaml` file.