### PR TITLE
Update ingress spec to be compliant with kubernetes version 1.22

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -13,7 +13,7 @@ description: A Helm chart for Kubernetes for the MOP TOM
 type: application
 
 # This is the chart version. Don't change it. The helmPipeline() appends the git hash to it as needed.
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. Don't change it. This value
 # is edited by helmPipeline() to be consistent with the latest git-tag on the master branch of the repository.

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -13,7 +13,7 @@ description: A Helm chart for Kubernetes for the MOP TOM
 type: application
 
 # This is the chart version. Don't change it. The helmPipeline() appends the git hash to it as needed.
-version: 0.3.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. Don't change it. This value
 # is edited by helmPipeline() to be consistent with the latest git-tag on the master branch of the repository.

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mop.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This change will be completely transparent to the application developer and users, we are just future-proofing ourselves to be compliant with future kubernetes versions. The chart has been templated and tested against kubernetes version 1.22.1, and is passes. It is safe to deploy now.

This will need to be deployed on both dev and prod to make this application compliant with the upcoming upgrade.

I've verified correctness via:

```
helm template helm-chart -f helm-chart/values-prod.yaml | kubeval --kubernetes-version 1.22.1 --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
PASS - mop/templates/serviceaccount.yaml contains a valid ServiceAccount (RELEASE-NAME-mop)
PASS - mop/templates/configmap.yaml contains a valid ConfigMap (RELEASE-NAME-mop)
PASS - mop/templates/service.yaml contains a valid Service (RELEASE-NAME-mop)
PASS - mop/templates/deployment.yaml contains a valid Deployment (RELEASE-NAME-mop)
PASS - mop/templates/cronjob-addgalacticcoordinates.yaml contains a valid CronJob (RELEASE-NAME-mop-addgalacticcoordinates)
PASS - mop/templates/cronjob-fitaliveevents.yaml contains a valid CronJob (RELEASE-NAME-mop-fitaliveevents)
PASS - mop/templates/cronjob-fitneedevents.yaml contains a valid CronJob (RELEASE-NAME-mop-fitneedevents)
PASS - mop/templates/cronjob-gaiaclassifier.yaml contains a valid CronJob (RELEASE-NAME-mop-gaiaclassifier)
PASS - mop/templates/cronjob-harvestasassn.yaml contains a valid CronJob (RELEASE-NAME-mop-harvestasassn)
PASS - mop/templates/cronjob-harvestgaia.yaml contains a valid CronJob (RELEASE-NAME-mop-harvestgaia)
PASS - mop/templates/cronjob-harvestmoa.yaml contains a valid CronJob (RELEASE-NAME-mop-harvestmoa)
PASS - mop/templates/cronjob-harvestogle.yaml contains a valid CronJob (RELEASE-NAME-mop-harvestogle)
PASS - mop/templates/cronjob-harvestztfdr3.yaml contains a valid CronJob (RELEASE-NAME-mop-harvestztfdr3)
PASS - mop/templates/cronjob-opentargetstoomegausers.yaml contains a valid CronJob (RELEASE-NAME-mop-opentargetstoomegausers)
PASS - mop/templates/cronjob-runtap.yaml contains a valid CronJob (RELEASE-NAME-mop-runtap)
PASS - mop/templates/ingress.yaml contains a valid Ingress (RELEASE-NAME-mop)
PASS - mop/templates/tests/test-connection.yaml contains a valid Pod (RELEASE-NAME-mop-test-connection)
```