### PR TITLE
Feature tap2 mpgh

### DIFF
--- a/mop/management/commands/fit_all_events_PSPL.py
+++ b/mop/management/commands/fit_all_events_PSPL.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
 
                        photometry = np.c_[time,phot]
 
-                       t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model,chi2_fit,red_chi2 = fittools.fit_PSPL_parallax(target.ra, target.dec, photometry, cores = options['cores'])
+                       t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model,chi2_fit,red_chi2 = fittools.fit_pspl_omega2(target.ra, target.dec, photometry)
 
                        #Add photometry model
 

--- a/mop/management/commands/fit_all_events_PSPL.py
+++ b/mop/management/commands/fit_all_events_PSPL.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
 
                        photometry = np.c_[time,phot]
 
-                       t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model,chi2_fit,red_chi2 = fittools.fit_pspl_omega2(target.ra, target.dec, photometry)
+                       t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model,chi2_fit,red_chi2, sw_test, ad_test, ks_test = fittools.fit_pspl_omega2(target.ra, target.dec, photometry)
 
                        #Add photometry model
 

--- a/mop/management/commands/fit_event_PSPL.py
+++ b/mop/management/commands/fit_event_PSPL.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
 
 
 
-           t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model,chi2_fit,red_chi2 = fittools.fit_pspl_omega2(target.ra, target.dec, photometry)
+           t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model,chi2_fit,red_chi2, sw_test, ad_test, ks_test = fittools.fit_pspl_omega2(target.ra, target.dec, photometry)
 
            #Add photometry model
 

--- a/mop/management/commands/fit_event_PSPL.py
+++ b/mop/management/commands/fit_event_PSPL.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
 
 
 
-           t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model,chi2_fit,red_chi2 = fittools.fit_PSPL_parallax(target.ra, target.dec, photometry, cores = options['cores'])
+           t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model,chi2_fit,red_chi2 = fittools.fit_pspl_omega2(target.ra, target.dec, photometry)
 
            #Add photometry model
 

--- a/mop/management/commands/fit_need_events_PSPL.py
+++ b/mop/management/commands/fit_need_events_PSPL.py
@@ -56,7 +56,7 @@ def run_fit(target, cores):
 
            photometry = np.c_[time,phot]
 
-           t0_fit,u0_fit,tE_fit,piEN_fit,piEE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,cov,model,chi2_fit,red_chi2 = fittools.fit_PSPL_parallax(target.ra, target.dec, photometry, cores = cores)
+           t0_fit, u0_fit, tE_fit, piEN_fit, piEE_fit, mag_source_fit, mag_blend_fit, mag_baseline_fit, cov, model, chi2_fit, red_chi2, sw_test, ad_test, ks_test = fittools.fit_pspl_omega2(target.ra, target.dec, photometry)
 
            # Add photometry model
 

--- a/mop/toolbox/fittools.py
+++ b/mop/toolbox/fittools.py
@@ -63,9 +63,9 @@ def fit_PSPL_omega2(photometry, emag_limit = None, cores = None):
         fit_tap.fit_parameters["tE"][1] = [1., 3000.]
         fit_tap.fit_parameters["u0"][1] = [0., 1.5]
         fit_tap.fit()
-        mag_blend_fit = flux_to_mag(fit_tap.fit_results["best_model"][4])
-        mag_source_fit = -99.
-        mag_baseline_fit = flux_to_mag(fit_tap.fit_results["best_model"][3] + fit_tap.fit_results["best_model"][4])
+        mag_blend_fit = -99.
+        mag_source_fit = flux_to_mag(fit_tap.fit_results["best_model"][4])
+        mag_baseline_fit = flux_to_mag(fit_tap.fit_results["best_model"][3])
 
     epsilon_numerical_noise = 1e-6
     if np.abs(fit_tap.fit_parameters["u0"][1][0] - fit_tap.fit_results['best_model'][1]) < epsilon_numerical_noise or\

--- a/mop/toolbox/fittools.py
+++ b/mop/toolbox/fittools.py
@@ -148,25 +148,27 @@ def fit_pspl_omega2(ra, dec, photometry, emag_limit=None):
     model_telescope.lightcurve_magnitude = model_telescope.lightcurve_magnitude[mask]
     try:
         res = fit_tap.model_residuals(fit_tap.fit_results['best_model'])
-        shapiro_wilk = stats.normal_Shapiro_Wilk((np.ravel(res[0]['photometry']) / np.ravel(res[1]['photometry'])))
-        anderson_darling = stats.normal_Anderson_Darling((np.ravel(res[0]['photometry']) / np.ravel(res[1]['photometry'])))
-        kolmogorov_smirnov = stats.normal_Kolmogorov_Smirnov((np.ravel(res[0]['photometry']) / np.ravel(res[1]['photometry'])))
+        sw_test = stats.normal_Shapiro_Wilk((np.ravel(res[0]['photometry']) / np.ravel(res[1]['photometry'])))
+        ad_test = stats.normal_Anderson_Darling((np.ravel(res[0]['photometry']) / np.ravel(res[1]['photometry'])))
+        ks_test = stats.normal_Kolmogorov_Smirnov((np.ravel(res[0]['photometry']) / np.ravel(res[1]['photometry'])))
         chi2_dof = np.sum((np.ravel(res[0]['photometry']) / np.ravel(res[1]['photometry'])) ** 2) / (
                 len(np.ravel(res[0]['photometry'])) - 5)
     except:
-        shapiro_wilk = "null"
-        anderson_darling = "null"
-        komogorov_smirnov = "null"
+        sw_test = "null"
+        ad_test = "null"
+        ks_test = "null"
         chi2_dof = "null"
     # chi2_fit is only an actual chi-squared if the loss function was deactivated
     try:
         to_return = [np.around(t0_fit, 3), np.around(u0_fit, 5), np.around(tE_fit, 3), np.around(piEN_fit, 5),
                      np.around(piEE_fit, 5),
                      np.around(mag_source_fit, 3), np.around(mag_blend_fit, 3), np.around(mag_baseline_fit, 3),
-                     fit_tap.fit_results["covariance_matrix"], model_telescope, np.around(chi2_fit, 3), chi2_dof]
+                     fit_tap.fit_results["covariance_matrix"], model_telescope, np.around(chi2_fit, 3), chi2_dof,
+                     sw_test, ad_test, ks_test]
     except:
         to_return = [np.around(t0_fit, 3), np.around(u0_fit, 5), np.around(tE_fit, 3), np.around(piEN_fit, 5),
                      np.around(piEE_fit, 5),
                      np.around(mag_source_fit, 3), mag_blend_fit, np.around(mag_baseline_fit, 3),
-                     fit_tap.fit_results["covariance_matrix"], model_telescope, np.around(chi2_fit, 3), chi2_dof]
+                     fit_tap.fit_results["covariance_matrix"], model_telescope, np.around(chi2_fit, 3), chi2_dof,
+                     sw_test, ad_test, ks_test]
     return to_return

--- a/mop/toolbox/fittools.py
+++ b/mop/toolbox/fittools.py
@@ -88,10 +88,9 @@ def fit_PSPL_omega2(ra, dec, photometry, emag_limit=None):
         mag_source_fit = flux_to_mag(fit_tap.fit_results["best_model"][3])
         mag_baseline_fit = flux_to_mag(fit_tap.fit_results["best_model"][3])
     else:
-        pspl = PSPL_model.PSPLmodel(current_event, parallax=['None', 0.],
-                                    blend_flux_parameter='noblend')
+        pspl = PSPL_model.PSPLmodel(current_event, parallax=['None', 0.])
         pspl.define_model_parameters()
-        fit_tap = TRF_fit.TRFfit(pspl, loss_function='soft_l1')
+        fit_tap = TRF_fit.TRFfit(pspl)
         fit_tap.fit_parameters["t0"][1] = [default_t0_lower, default_t0_upper + delta_t0]
         fit_tap.fit_parameters["tE"][1] = [1., 3000.]
         fit_tap.fit_parameters["u0"][1] = [0., 2.0]

--- a/mop/toolbox/fittools.py
+++ b/mop/toolbox/fittools.py
@@ -1,190 +1,85 @@
 import numpy as np
 from pyLIMA import event
 from pyLIMA import telescopes
-from pyLIMA import microlmodels
-from pyLIMA import microloutputs
-from pyLIMA import microltoolbox
+from pyLIMA.fits import TRF_fit
+from pyLIMA.models import PSPL_model
 
-def chi2(params,fit):
 
-     chi2 = np.sum(fit.residuals_LM(params)**2)
-     return chi2
+def chi2(params, fit):
+
+    chi2 = np.sum(fit.residuals_LM(params)**2)
+    return chi2
+
 
 def flux_to_mag(flux):
 
-        ZP_pyLIMA = 27.4
-        magnitude = ZP_pyLIMA -2.5*np.log10(flux)
-        return magnitude
-
-def fit_PSPL(photometry, emag_limit = None, cores = None):
-
-       current_event = event.Event()
-       current_event.name = 'MOP_to_fit'
-       filters = np.unique(photometry[:,-1])
-
-       for ind,filt in enumerate(filters):
-
-           if emag_limit:
-
-               mask = (photometry[:,-1] == filt) & (np.abs(photometry[:,-2].astype(float))<emag_limit)
-
-           else:
-
-               mask = (photometry[:,-1] == filt)
-           lightcurve = photometry[mask,:-1].astype(float)
-
-           telescope = telescopes.Telescope(name='Tel_'+str(ind), camera_filter=filt,
-                                            light_curve_magnitude=lightcurve,
-                                            light_curve_magnitude_dictionnary={'time': 0, 'mag': 1, 'err_mag': 2},
-                                            clean_the_lightcurve='Yes')
-
-           if len(lightcurve)>5:
-               current_event.telescopes.append(telescope)
-
-       Model = microlmodels.create_model('PSPL', current_event, parallax=['None', 0])
-       Model.parameters_boundaries[0] = [Model.parameters_boundaries[0][0],Model.parameters_boundaries[0][-1]+500]
-       Model.parameters_boundaries[1] = [0,2]
-
-       if cores != 0:
-
-           import multiprocessing
-           with multiprocessing.Pool(processes=cores) as pool:
-                current_event.fit(Model, 'DE',DE_population_size=10,flux_estimation_MCMC = 'polyfit',computational_pool = pool)
-
-       else:
-
-           current_event.fit(Model, 'DE',DE_population_size=10,flux_estimation_MCMC = 'polyfit')
+    ZP_pyLIMA = 27.4
+    magnitude = ZP_pyLIMA -2.5*np.log10(flux)
+    return magnitude
 
 
+def fit_PSPL_omega2(photometry, emag_limit = None, cores = None):
 
+    current_event = event.Event()
+    current_event.name = 'MOP_to_fit'
+    filters = np.unique(photometry[:, -1])
 
-       t0_fit =  current_event.fits[-1].fit_results[0]
-       u0_fit =  current_event.fits[-1].fit_results[1]
-       tE_fit =  current_event.fits[-1].fit_results[2]
-       chi2_fit = current_event.fits[-1].fit_results[-1]
+    for ind, filt in enumerate(filters):
 
-       mag_source_fit = flux_to_mag( current_event.fits[-1].fit_results[3])
-       mag_blend_fit = flux_to_mag( current_event.fits[-1].fit_results[3]*current_event.fits[-1].fit_results[4])
-       mag_baseline_fit = flux_to_mag( current_event.fits[-1].fit_results[3]*(1+current_event.fits[-1].fit_results[4]))
+        if emag_limit:
 
-       if np.isnan(mag_blend_fit):
-           mag_blend_fit = "null"
+            mask = (photometry[:, -1] == filt) & (np.abs(photometry[:, -2].astype(float)) < emag_limit)
 
+        else:
 
+            mask = (photometry[:, -1] == filt)
+        lightcurve = photometry[mask, :-1].astype(float)
+        # Treating all sites as ground-based without coordinates
+        telescope = telescopes.Telescope(name='Tel_'+str(ind), camera_filter=filt,
+                                         light_curve=lightcurve,
+                                         light_curve_names=['time', 'mag', 'err_mag'],
+                                         light_curve_units=['JD', 'mag', 'err_mag'])
+        if len(lightcurve) > 5:
+            current_event.telescopes.append(telescope)
 
+    pspl = PSPL_model.PSPLmodel(current_event, parallax=['None', 0.])
+    pspl.define_model_parameters()
+    fit_tap = TRF_fit.TRFfit(pspl, loss_function='soft_l1')
+    fit_tap.fit_parameters["tE"][1] = [1., 3000.]
+    fit_tap.fit_parameters["u0"][1] = [0., 1.5]
+    fit_tap.fit()
+    cov_fit1 = fit_tap.fit_results["covariance_matrix"]
+    best_fit1 = fit_tap.fit_results["best_model"]
+    mag_blend_fit = flux_to_mag(fit_tap.fit_results["best_model"][4])
+    mag_source_fit = flux_to_mag(fit_tap.fit_results["best_model"][3])
+    mag_baseline_fit = flux_to_mag(fit_tap.fit_results["best_model"][3] + fit_tap.fit_results["best_model"][4])
+    if (np.abs(best_fit1[4]) < 3. * cov_fit1[4, 4] ** 0.5) or\
+            (np.abs(best_fit1[3]) < 3. * cov_fit1[3, 3] ** 0.5) or\
+            (np.abs(best_fit1[2]) < 3. * cov_fit1[2, 2] ** 0.5):
+        pspl = PSPL_model.PSPLmodel(current_event, parallax=['None', 0.],
+                                    blend_flux_parameter='noblend')
+        pspl.define_model_parameters()
+        fit_tap = TRF_fit.TRFfit(pspl, loss_function='soft_l1')
+        fit_tap.fit_parameters["tE"][1] = [1., 3000.]
+        fit_tap.fit_parameters["u0"][1] = [0., 1.5]
+        fit_tap.fit()
+        mag_blend_fit = flux_to_mag(fit_tap.fit_results["best_model"][4])
+        mag_source_fit = -99.
+        mag_baseline_fit = flux_to_mag(fit_tap.fit_results["best_model"][3] + fit_tap.fit_results["best_model"][4])
 
-       return [t0_fit,u0_fit,tE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,chi2_fit]
+    epsilon_numerical_noise = 1e-6
+    if np.abs(fit_tap.fit_parameters["u0"][1][0] - fit_tap.fit_results['best_model'][1]) < epsilon_numerical_noise or\
+            np.abs(fit_tap.fit_parameters["u0"][1][1] - fit_tap.fit_results['best_model'][1]) < epsilon_numerical_noise or\
+            np.abs(fit_tap.fit_parameters["tE"][1][1] - fit_tap.fit_results['best_model'][2]) < epsilon_numerical_noise or\
+            np.abs(fit_tap.fit_parameters["tE"][1][1] - fit_tap.fit_results['best_model'][2]) < epsilon_numerical_noise:
+        t0_fit = None
+        u0_fit = None
+        tE_fit = None
+        chi2_fit = None
 
-def fit_PSPL_parallax(ra,dec,photometry, emag_limit = None, cores = None):
+    t0_fit = fit_tap.fit_results["best_model"][0]
+    u0_fit = fit_tap.fit_results["best_model"][1]
+    tE_fit = fit_tap.fit_results["best_model"][2]
+    chi2_fit = fit_tap.fit_results["chi2"]
 
-       # Filter orders
-       filters_order = ['I','ip','i_ZTF','r_ZTF','R','g_ZTF','gp','G']
-
-
-       filters = np.unique(photometry[:,-1])
-       order = []
-       for fil in filters_order:
-
-           mask = np.where(filters==fil)[0]
-           if len(mask)!= 0:
-                order += mask.tolist()
-
-       for fil in filters:
-
-           if fil not in filters_order:
-                mask = np.where(filters==fil)[0]
-                if len(mask)!= 0:
-                    order += mask.tolist()
-       filters = filters[order]
-
-
-
-       t0_fit,u0_fit,tE_fit,mag_source_fit,mag_blend_fit,mag_baseline_fit,chi2_fit = fit_PSPL(photometry, emag_limit = None, cores = cores)
-
-       current_event = event.Event()
-       current_event.name = 'MOP_to_fit'
-
-       current_event.ra = ra
-       current_event.dec = dec
-
-       for ind,filt in enumerate(filters):
-
-           if emag_limit:
-
-               mask = (photometry[:,-1] == filt) & (np.abs(photometry[:,-2].astype(float))<emag_limit)
-
-           else:
-
-               mask = (photometry[:,-1] == filt)
-           lightcurve = photometry[mask,:-1].astype(float)
-
-           telescope = telescopes.Telescope(name='Tel_'+str(ind), camera_filter=filt,
-                                            light_curve_magnitude=lightcurve,
-                                            light_curve_magnitude_dictionnary={'time': 0, 'mag': 1, 'err_mag': 2},
-                                            clean_the_lightcurve='Yes')
-
-           if len(lightcurve)>5:
-               current_event.telescopes.append(telescope)
-
-
-       t0_par = t0_fit
-
-       Model_parallax = microlmodels.create_model('PSPL', current_event, parallax=['Full', t0_par])
-       Model_parallax.parameters_boundaries[0] = [t0_fit-100,t0_fit+100]
-
-       Model_parallax.parameters_boundaries[1] = [-2,2]
-       Model_parallax.parameters_boundaries[2] = [0.1,500]
-       #Model_parallax.parameters_boundaries[3] = [-1,1]
-       #Model_parallax.parameters_boundaries[4] = [-1,1]
-       Model_parallax.parameters_guess = [ t0_fit,u0_fit,tE_fit,0,0]
-
-       if cores !=0:
-
-           import multiprocessing
-           with multiprocessing.Pool(processes=cores) as pool:
-                current_event.fit(Model_parallax, 'DE',DE_population_size=10,flux_estimation_MCMC = 'polyfit',computational_pool = pool)
-
-       else:
-
-           current_event.fit(Model_parallax, 'DE',DE_population_size=10,flux_estimation_MCMC = 'polyfit')
-
-       #if (chi2_fit-current_event.fits[-1].fit_results[-1])/current_event.fits[-1].fit_results[-1]<0.1:
-
-            #return [t0_fit,u0_fit,tE_fit,None,None,mag_source_fit,mag_blend_fit,mag_baseline_fit]
-
-       t0_fit = current_event.fits[-1].fit_results[0]
-       u0_fit =  current_event.fits[-1].fit_results[1]
-       tE_fit =  current_event.fits[-1].fit_results[2]
-       piEN_fit =  current_event.fits[-1].fit_results[3]
-       piEE_fit =  current_event.fits[-1].fit_results[4]
-       chi2_fit = current_event.fits[-1].fit_results[-1]
-       red_chi2 = chi2_fit / float(len(lightcurve)-7)
-
-       mag_source_fit = flux_to_mag( current_event.fits[-1].fit_results[5])
-       mag_blend_fit = flux_to_mag( current_event.fits[-1].fit_results[5]*current_event.fits[-1].fit_results[6])
-       mag_baseline_fit = flux_to_mag( current_event.fits[-1].fit_results[5]*(1+current_event.fits[-1].fit_results[6]))
-
-       if np.isnan(mag_blend_fit):
-           mag_blend_fit = "null"
-
-
-       microloutputs.create_the_fake_telescopes(current_event.fits[0],current_event.fits[0].fit_results[:-1])
-       model_telescope = current_event.fits[0].event.fake_telescopes[0]
-       pyLIMA_parameters = Model_parallax.compute_pyLIMA_parameters(current_event.fits[0].fit_results[:-1])
-       flux_model = current_event.fits[0].model.compute_the_microlensing_model(model_telescope, pyLIMA_parameters)[0]
-       magnitude = microltoolbox.flux_to_magnitude(flux_model)
-       model_telescope.lightcurve_magnitude[:,1] = magnitude
-
-       mask = ~np.isnan(magnitude)
-       model_telescope.lightcurve_magnitude = model_telescope.lightcurve_magnitude[mask]
-
-
-       try:
-            to_return = [np.around(t0_fit,3),np.around(u0_fit,5),np.around(tE_fit,3),np.around(piEN_fit,5),np.around(piEE_fit,5),
-               np.around(mag_source_fit,3),np.around(mag_blend_fit,3),np.around(mag_baseline_fit,3),
-               current_event.fits[-1].fit_covariance,model_telescope,np.around(chi2_fit,3),red_chi2]
-       except:
-            to_return = [np.around(t0_fit,3),np.around(u0_fit,5),np.around(tE_fit,3),np.around(piEN_fit,5),np.around(piEE_fit,5),
-               np.around(mag_source_fit,3),mag_blend_fit,np.around(mag_baseline_fit,3),
-               current_event.fits[-1].fit_covariance,model_telescope,np.around(chi2_fit,3),red_chi2]
-       return to_return
+    return [t0_fit, u0_fit, tE_fit, mag_source_fit, mag_blend_fit, mag_baseline_fit, chi2_fit]

--- a/mop/toolbox/fittools.py
+++ b/mop/toolbox/fittools.py
@@ -14,16 +14,34 @@ def chi2(params, fit):
 def flux_to_mag(flux):
 
     ZP_pyLIMA = 27.4
-    magnitude = ZP_pyLIMA -2.5*np.log10(flux)
+    magnitude = ZP_pyLIMA - 2.5 * np.log10(flux)
     return magnitude
 
 
-def fit_PSPL_omega2(photometry, emag_limit = None, cores = None):
+def fit_PSPL_omega2(ra, dec, photometry, emag_limit=None):
+    # Default filter sequence for establishing survey dataset
+    filters_order = ['I', 'ip', 'i_ZTF', 'r_ZTF', 'R', 'g_ZTF', 'gp', 'G']
 
+    filters = np.unique(photometry[:, -1])
+    order = []
+    for fil in filters_order:
+
+        mask = np.where(filters == fil)[0]
+        if len(mask) != 0:
+            order += mask.tolist()
+
+    for fil in filters:
+
+        if fil not in filters_order:
+            mask = np.where(filters == fil)[0]
+            if len(mask) != 0:
+                order += mask.tolist()
+
+    filters = filters[order]
     current_event = event.Event()
     current_event.name = 'MOP_to_fit'
     filters = np.unique(photometry[:, -1])
-
+    lightcurve = []
     for ind, filt in enumerate(filters):
 
         if emag_limit:
@@ -45,14 +63,15 @@ def fit_PSPL_omega2(photometry, emag_limit = None, cores = None):
     pspl = PSPL_model.PSPLmodel(current_event, parallax=['None', 0.])
     pspl.define_model_parameters()
     fit_tap = TRF_fit.TRFfit(pspl, loss_function='soft_l1')
+    delta_t0 = 10.
+    default_t0_lower = fit_tap.fit_parameters["t0"][1][0]
+    default_t0_upper = fit_tap.fit_parameters["t0"][1][1]
+    fit_tap.fit_parameters["t0"][1] = [default_t0_lower, default_t0_upper + delta_t0]
     fit_tap.fit_parameters["tE"][1] = [1., 3000.]
-    fit_tap.fit_parameters["u0"][1] = [0., 1.5]
+    fit_tap.fit_parameters["u0"][1] = [0., 2.0]
     fit_tap.fit()
     cov_fit1 = fit_tap.fit_results["covariance_matrix"]
     best_fit1 = fit_tap.fit_results["best_model"]
-    mag_blend_fit = flux_to_mag(fit_tap.fit_results["best_model"][4])
-    mag_source_fit = flux_to_mag(fit_tap.fit_results["best_model"][3])
-    mag_baseline_fit = flux_to_mag(fit_tap.fit_results["best_model"][3] + fit_tap.fit_results["best_model"][4])
     if (np.abs(best_fit1[4]) < 3. * cov_fit1[4, 4] ** 0.5) or\
             (np.abs(best_fit1[3]) < 3. * cov_fit1[3, 3] ** 0.5) or\
             (np.abs(best_fit1[2]) < 3. * cov_fit1[2, 2] ** 0.5):
@@ -60,26 +79,56 @@ def fit_PSPL_omega2(photometry, emag_limit = None, cores = None):
                                     blend_flux_parameter='noblend')
         pspl.define_model_parameters()
         fit_tap = TRF_fit.TRFfit(pspl, loss_function='soft_l1')
+        fit_tap.fit_parameters["t0"][1] = [default_t0_lower, default_t0_upper + delta_t0]
         fit_tap.fit_parameters["tE"][1] = [1., 3000.]
-        fit_tap.fit_parameters["u0"][1] = [0., 1.5]
+        fit_tap.fit_parameters["u0"][1] = [0., 2.0]
         fit_tap.fit()
-        mag_blend_fit = -99.
-        mag_source_fit = flux_to_mag(fit_tap.fit_results["best_model"][4])
+        # default null as in the former implementation
+        mag_blend_fit = "null"
+        mag_source_fit = flux_to_mag(fit_tap.fit_results["best_model"][3])
         mag_baseline_fit = flux_to_mag(fit_tap.fit_results["best_model"][3])
+    else:
+        pspl = PSPL_model.PSPLmodel(current_event, parallax=['None', 0.],
+                                    blend_flux_parameter='noblend')
+        pspl.define_model_parameters()
+        fit_tap = TRF_fit.TRFfit(pspl, loss_function='soft_l1')
+        fit_tap.fit_parameters["t0"][1] = [default_t0_lower, default_t0_upper + delta_t0]
+        fit_tap.fit_parameters["tE"][1] = [1., 3000.]
+        fit_tap.fit_parameters["u0"][1] = [0., 2.0]
+        fit_tap.fit()
+        mag_blend_fit = flux_to_mag(fit_tap.fit_results["best_model"][4])
+        mag_source_fit = flux_to_mag(fit_tap.fit_results["best_model"][3])
+        mag_baseline_fit = flux_to_mag(fit_tap.fit_results["best_model"][3] + fit_tap.fit_results["best_model"][4])
 
     epsilon_numerical_noise = 1e-6
     if np.abs(fit_tap.fit_parameters["u0"][1][0] - fit_tap.fit_results['best_model'][1]) < epsilon_numerical_noise or\
             np.abs(fit_tap.fit_parameters["u0"][1][1] - fit_tap.fit_results['best_model'][1]) < epsilon_numerical_noise or\
             np.abs(fit_tap.fit_parameters["tE"][1][1] - fit_tap.fit_results['best_model'][2]) < epsilon_numerical_noise or\
             np.abs(fit_tap.fit_parameters["tE"][1][1] - fit_tap.fit_results['best_model'][2]) < epsilon_numerical_noise:
-        t0_fit = None
-        u0_fit = None
-        tE_fit = None
-        chi2_fit = None
-
-    t0_fit = fit_tap.fit_results["best_model"][0]
-    u0_fit = fit_tap.fit_results["best_model"][1]
-    tE_fit = fit_tap.fit_results["best_model"][2]
-    chi2_fit = fit_tap.fit_results["chi2"]
-
-    return [t0_fit, u0_fit, tE_fit, mag_source_fit, mag_blend_fit, mag_baseline_fit, chi2_fit]
+        t0_fit = np.nan
+        u0_fit = np.nan
+        tE_fit = np.nan
+        chi2_fit = np.nan
+    else:
+        t0_fit = fit_tap.fit_results["best_model"][0]
+        u0_fit = fit_tap.fit_results["best_model"][1]
+        tE_fit = fit_tap.fit_results["best_model"][2]
+        chi2_fit = fit_tap.fit_results["chi2"]
+    piEN_fit = 0.0
+    piEE_fit = 0.0
+    red_chi2 = chi2_fit / float(len(lightcurve) - 5)
+    # model_telescope = toolbox.fake_telescopes.create_a_fake_telescope()
+    # pyLIMA_parameters = pspl.compute_pyLIMA_parameters(fit_tap.fit_results["best_model"])
+    # model = pspl.compute_the_microlensing_model(model_telescope, pyLIMA_parameters)
+    model_telescope = None
+    try:
+        to_return = [np.around(t0_fit, 3), np.around(u0_fit, 5), np.around(tE_fit, 3), np.around(piEN_fit, 5),
+                     np.around(piEE_fit, 5),
+                     np.around(mag_source_fit, 3), np.around(mag_blend_fit, 3), np.around(mag_baseline_fit, 3),
+                     fit_tap.fit_results["covariance_matrix"], model_telescope, np.around(chi2_fit, 3), red_chi2]
+    except:
+        to_return = [np.around(t0_fit, 3), np.around(u0_fit, 5), np.around(tE_fit, 3), np.around(piEN_fit, 5),
+                     np.around(piEE_fit, 5),
+                     np.around(mag_source_fit, 3), mag_blend_fit, np.around(mag_baseline_fit, 3),
+                     fit_tap.fit_results["covariance_matrix"], model_telescope, np.around(chi2_fit, 3), red_chi2]
+    return to_return

--- a/mop/toolbox/fittools.py
+++ b/mop/toolbox/fittools.py
@@ -102,7 +102,7 @@ def fit_PSPL_omega2(ra, dec, photometry, emag_limit=None):
     epsilon_numerical_noise = 1e-6
     if np.abs(fit_tap.fit_parameters["u0"][1][0] - fit_tap.fit_results['best_model'][1]) < epsilon_numerical_noise or\
             np.abs(fit_tap.fit_parameters["u0"][1][1] - fit_tap.fit_results['best_model'][1]) < epsilon_numerical_noise or\
-            np.abs(fit_tap.fit_parameters["tE"][1][1] - fit_tap.fit_results['best_model'][2]) < epsilon_numerical_noise or\
+            np.abs(fit_tap.fit_parameters["tE"][1][0] - fit_tap.fit_results['best_model'][2]) < epsilon_numerical_noise or\
             np.abs(fit_tap.fit_parameters["tE"][1][1] - fit_tap.fit_results['best_model'][2]) < epsilon_numerical_noise:
         t0_fit = np.nan
         u0_fit = np.nan

--- a/mop/toolbox/fittools.py
+++ b/mop/toolbox/fittools.py
@@ -99,7 +99,7 @@ def fit_PSPL_omega2(ra, dec, photometry, emag_limit=None):
         mag_source_fit = flux_to_mag(fit_tap.fit_results["best_model"][3])
         mag_baseline_fit = flux_to_mag(fit_tap.fit_results["best_model"][3] + fit_tap.fit_results["best_model"][4])
 
-    epsilon_numerical_noise = 1e-6
+    epsilon_numerical_noise = 1e-4
     if np.abs(fit_tap.fit_parameters["u0"][1][0] - fit_tap.fit_results['best_model'][1]) < epsilon_numerical_noise or\
             np.abs(fit_tap.fit_parameters["u0"][1][1] - fit_tap.fit_results['best_model'][1]) < epsilon_numerical_noise or\
             np.abs(fit_tap.fit_parameters["tE"][1][0] - fit_tap.fit_results['best_model'][2]) < epsilon_numerical_noise or\


### PR DESCRIPTION
The new TAP fit structure could replace the parallaxDE  fit with a static PSPL TRF fit using pyLIMAv1.9 and checking if the blend is constrained with a soft_l1 loss function. If blend is constrained a chisquare TRF fit is returned. If the TRF limit is reached in u0 and tE, PSPL parameters return np.nan.
The model_telescope is now following the pyLIMAv1.9 syntax, i.e. it needs to be checked if the plotter picks it up correctly.