### PR TITLE
Issue 67

### DIFF
--- a/mop/management/commands/run_TAP.py
+++ b/mop/management/commands/run_TAP.py
@@ -3,6 +3,7 @@ from tom_dataproducts.models import ReducedDatum
 from tom_targets.models import Target,TargetExtra,TargetList
 from astropy.time import Time, TimeDelta
 from mop.toolbox import TAP
+from mop.toolbox import TAP_priority
 from mop.toolbox import obs_control
 from mop.toolbox import omegaII_strategy
 from mop.toolbox import interferometry_prediction
@@ -56,6 +57,8 @@ class Command(BaseCommand):
                     t0_pspl = event.extra_fields['t0']
                     u0_pspl = event.extra_fields['u0']
                     tE_pspl = event.extra_fields['tE']
+                    t0_pspl_error = event.extra_fields['t0_error']
+                    tE_pspl_error = event.extra_fields['tE_error']
 
                     covariance = load_covar_matrix(event.extra_fields['Fit_covariance'])
 
@@ -63,8 +66,8 @@ class Command(BaseCommand):
                     category = TAP.categorize_event_timescale(event)
 
                     # Calculate the priority of this event for different science goals
-                    planet_priority = TAP.TAP_planet_priority(time_now,t0_pspl,u0_pspl,tE_pspl)
-                    planet_priority_error = TAP.TAP_planet_priority_error(time_now,t0_pspl,u0_pspl,tE_pspl,covariance)
+                    planet_priority = TAP_priority.TAP_planet_priority(time_now,t0_pspl,u0_pspl,tE_pspl)
+                    planet_priority_error = TAP_priority.TAP_planet_priority_error(time_now,t0_pspl,u0_pspl,tE_pspl,covariance)
                     if verbose: print('Planet priority: ',planet_priority, planet_priority_error)
 
                     # ACTION RAS: Need to calculate this if not already available.
@@ -75,8 +78,8 @@ class Command(BaseCommand):
                         t_last = Time.now(jd) - TimeDelta(days=30.0)
                     if verbose: print('Last datapoint: ',t_last)
 
-                    long_priority = TAP.TAP_long_event_priority(time_now, t_last, tE_pspl)
-                    long_priority_error = TAP.TAP_long_event_priority_error(tE_pspl, covariance)
+                    long_priority = TAP_priority.TAP_long_event_priority(time_now, t_last, tE_pspl)
+                    long_priority_error = TAP_priority.TAP_long_event_priority_error(tE_pspl, covariance)
                     if verbose: print('Long tE priority: ',long_priority, long_priority_error)
 
                     # Storing both types of priority as extra_params and also as ReducedDatums so
@@ -156,6 +159,7 @@ class Command(BaseCommand):
                                 if verbose: print('mag_baseline: ', mag_baseline)
                                 observing_mode = TAP.TAP_observing_mode(planet_priority, planet_priority_error,
                                                                     long_priority, long_priority_error,
+                                                                    tE_pspl, tE_pspl_error, t0_pspl, t0_pspl_error,
                                                                     mag_now, mag_baseline)
                             else:
                                 observing_mode = None

--- a/mop/toolbox/TAP.py
+++ b/mop/toolbox/TAP.py
@@ -24,18 +24,17 @@ def TAP_anomaly():
 
 def TAP_observing_mode(planet_priority, planet_priority_error,
                        long_priority, long_priority_error,
-                       t_E, t_E_error, t_0, t_0_error,
-                       mag_now, mag_baseline):
+                       t_E, t_E_error, mag_now, mag_baseline):
 
     if (TAP_priority.check_planet_priority(planet_priority, planet_priority_error, mag_baseline, mag_now)):
         return 'priority_stellar_event'
 
     elif (TAP_priority.check_long_priority(long_priority, long_priority_error,
-                        t_E, t_E_error, t_0, t_0_error, t_now,mag_baselin) == 'priority'):
+                        t_E, t_E_error, mag_baseline) == 'priority'):
         return 'priority_long_event'
 
     elif (TAP_priority.check_long_priority(long_priority, long_priority_error,
-                        t_E, t_E_error, t_0, t_0_error, t_now,mag_baselin) == 'regular')
+                        t_E, t_E_error, mag_baseline) == 'regular')
         return 'regular_long_event'
 
     else:

--- a/mop/toolbox/TAP.py
+++ b/mop/toolbox/TAP.py
@@ -14,6 +14,7 @@ from pyLIMA import telescopes
 from shapely.geometry import Point
 from shapely.geometry.polygon import Polygon
 
+import TAP_priority
 
 ZP = 27.4 #pyLIMA convention
 
@@ -22,16 +23,19 @@ def TAP_anomaly():
     pass
 
 def TAP_observing_mode(planet_priority, planet_priority_error,
-                           long_priority, long_priority_error,
-                           mag_now, mag_baseline):
+                       long_priority, long_priority_error,
+                       t_E, t_E_error, t_0, t_0_error,
+                       mag_now, mag_baseline):
 
-    if (planet_priority>10) & (planet_priority/planet_priority_error>3) & (mag_baseline-mag_now>2) & (mag_now<19): #mag cut for high blended events
+    if (TAP_priority.check_planet_priority(planet_priority, planet_priority_error, mag_baseline, mag_now)):
         return 'priority_stellar_event'
 
-    elif (long_priority > 50) & (mag_now < 19) & (mag_baseline < 19):
+    elif (TAP_priority.check_long_priority(long_priority, long_priority_error,
+                        t_E, t_E_error, t_0, t_0_error, t_now,mag_baselin) == 'priority'):
         return 'priority_long_event'
 
-    elif (long_priority > 10) & (mag_now < 19) & (mag_baseline < 19):
+    elif (TAP_priority.check_long_priority(long_priority, long_priority_error,
+                        t_E, t_E_error, t_0, t_0_error, t_now,mag_baselin) == 'regular')
         return 'regular_long_event'
 
     else:
@@ -109,89 +113,7 @@ def set_target_sky_location(target):
         sky_location = 'Outside HCZ'
     target.save(extras={'Sky_location': sky_location})
 
-def psi_derivatives_squared(t,te,u0,t0):
-    """if you prefer to have the derivatives for a simple
-       error propagation without correlation
-    """
-    x0 = u0**2
-    x1 = te**(-2)
-    x2 = (t - t0)**2
-    x3 = x1*x2
-    x4 = x0 + x3
-    x5 = x2/te**3
-    x6 = x4*x5
-    x7 = x4 + 4.0
-    x8 = x5*x7
-    x9 = (x4*x7)**0.5
-    x10 = 1/(x4*x7)
-    x11 = x10/x9
-    x12 = x10*x9
-    x13 = 0.125/(0.5*x0 + 0.5*x3 + 0.5*x9 + 1)**2
-    x14 = u0*x4
-    x15 = u0*x7
-    x16 = x1*(-2*t + 2*t0)
-    x17 = (1/2)*x16
-    x18 = x17*x4
-    x19 = x17*x7
 
-    c0 = 16.0*(x11*(x6 + x8) - x13*(-x12*(-x6 - x8) + 2*x5))**2
-    c1 = 16.0*(x11*(-x14 - x15) - x13*(-2*u0 - x12*(x14 + x15)))**2
-    c2 = 16.0*(x11*(-x18 - x19) - x13*(-x12*(x18 + x19) - x16))**2
-    #i.e. for te, u0, to
-    return [c0, c1, c2 ]
-
-def TAP_planet_priority_error(time_now,t0_pspl,u0_pspl,tE_pspl,covariance):
-    """
-    This function calculates the priority for ranking
-    microlensing events based on the planet probability psi
-    as defined by Dominik 2009 and estimates the cost of
-    observations based on an empiric RMS estimate
-    obtained from a DANDIA reduction of K2C9 Sinistro
-    observations from 2016. It expects the overhead to be
-    60 seconds and also return the current Paczynski
-    light curve magnification.
-    """
-
-    usqr = u0_pspl**2 + ((time_now - t0_pspl) / tE_pspl)**2
-
-    dpsipdu = -8*(usqr+2)/(usqr*(usqr+4)**1.5)
-    dpsipdu += 4*(usqr**0.5*(usqr+4)**0.5+usqr+2)/(usqr+2+(usqr+4)**0.5)**2*1/(usqr+4)**0.5
-
-
-
-
-    dUdto = -(time_now - t0_pspl) / (tE_pspl ** 2 *usqr**0.5)
-    dUduo = u0_pspl/ usqr**0.5
-    dUdtE = -(time_now - t0_pspl) ** 2 / (tE_pspl ** 3 * usqr**0.5)
-
-    Jacob = np.zeros(len(covariance))
-    Jacob[0] = dpsipdu*dUdto
-    Jacob[1] = dpsipdu*dUduo
-    Jacob[2] = dpsipdu*dUdtE
-
-
-    error_psip = np.dot(Jacob.T,np.dot(covariance,Jacob))**0.5
-
-    return error_psip #/ (calculate_exptime_omega_sdss_i(mag) + 60.)
-
-def TAP_planet_priority(time_now,t0_pspl,u0_pspl,tE_pspl):
-    """
-    This function calculates the priority for ranking
-    microlensing events based on the planet probability psi
-    as defined by Dominik 2009 and estimates the cost of
-    observations based on an empiric RMS estimate
-    obtained from a DANDIA reduction of K2C9 Sinistro
-    observations from 2016. It expects the overhead to be
-    60 seconds and also return the current Paczynski
-    light curve magnification.
-    """
-    usqr = u0_pspl**2 + ((time_now - t0_pspl) / tE_pspl)**2
-    pspl_deno = (usqr * (usqr + 4.))**0.5
-    if pspl_deno < 1e-10:
-        pspl_deno = 10000.
-    psip = 4.0 / (pspl_deno) - 2.0 / (usqr + 2.0 + pspl_deno)
-
-    return psip
 
 
 
@@ -341,72 +263,6 @@ def event_not_in_OMEGA_II(ra, dec, KMTNet_fields):
         not_in_OMEGA_II = True
 
     return not_in_OMEGA_II
-
-def TAP_long_event_priority(t_now, t_last, t_E):
-    """
-    This function calculates priority of a long microlensing event.
-    If the event has a timescale equal to t_E_base, and was not
-    observed for t_obs_gap days, the priority should be close to 10.
-    If the event was not observed for more than 10 days,
-    the priority is boosted by 10.
-    If the fit was bad (indicated by t_E being a NaN), than
-    the priority drops to 0.
-    Inspired by Horn et al. 2009.
-
-    :param t_now: current JD
-    :param t_last: JD of the latest datapoint in any lightcurve
-                    assigned to the dataset
-    :param t_E: Einstein timescale of the event
-
-    :return: priority of the long microlensing event
-    """
-
-    if (np.isnan(t_E)):
-        # t_E may hit the fit bounds. This means, the fit was
-        # wrong. In this case the event should not be observed
-        # and wait for a better estimate of the values.
-        psi = 0.
-    else:
-        t_E_base = 250.
-        t_obs_gap = 2.
-
-        # Events with t_E of t_E_base days will have priority 10.
-        psi = t_E / t_E_base
-
-        # If the event was not observed for t_obs_gap days the priority
-        # should rise.
-        delta_t = t_now - t_last
-        x = (delta_t / t_obs_gap) - t_obs_gap
-        psi *= 10. * 1. / (1. + np.exp(-x))
-
-        # The event priority should be boosted if it was not
-        # observed for more than 10 days and it is a long event.
-        if (delta_t > 10. and t_E / t_E_base > 0.8 ):
-            psi *= 10.
-
-    return psi
-
-def TAP_long_event_priority_error(t_E, covariance):
-    """
-    This function calculates error of the priority
-    of a long microlensing event.
-
-    :param t_E: Einstein timescale of the event
-    :param covariance: covariance matrix
-
-    :return: error of the priority of the long microlensing event.
-    """
-
-    t_E_base = 250.
-
-    if(np.isnan(t_E)):
-        err_psi = 0.
-    else:
-        # Simple derevative
-        err_t_E = covariance[2,2]
-        err_psi = err_t_E / t_E_base
-
-    return err_psi
 
 def TAP_time_last_datapoint(target):
     """

--- a/mop/toolbox/TAP_priority.py
+++ b/mop/toolbox/TAP_priority.py
@@ -121,10 +121,11 @@ def TAP_long_event_priority(t_now, t_last, t_E, t_E_base = 75.):
         x = (delta_t / t_obs_gap) - t_obs_gap
         psi *= 10. / (1. + np.exp(-x))
 
+        # KK: Boosting turned off, short timescale events were promoted.
         # The event priority should be boosted if it was not
         # observed for more than 10 days and it is a long event.
-        if (delta_t > 10.):
-            psi *= 10.
+        # if (delta_t > 10.):
+        #     psi *= 10.
 
     return psi
 

--- a/mop/toolbox/TAP_priority.py
+++ b/mop/toolbox/TAP_priority.py
@@ -1,0 +1,180 @@
+import numpy as np
+
+def psi_derivatives_squared(t,te,u0,t0):
+    """if you prefer to have the derivatives for a simple
+       error propagation without correlation
+    """
+    x0 = u0**2
+    x1 = te**(-2)
+    x2 = (t - t0)**2
+    x3 = x1*x2
+    x4 = x0 + x3
+    x5 = x2/te**3
+    x6 = x4*x5
+    x7 = x4 + 4.0
+    x8 = x5*x7
+    x9 = (x4*x7)**0.5
+    x10 = 1/(x4*x7)
+    x11 = x10/x9
+    x12 = x10*x9
+    x13 = 0.125/(0.5*x0 + 0.5*x3 + 0.5*x9 + 1)**2
+    x14 = u0*x4
+    x15 = u0*x7
+    x16 = x1*(-2*t + 2*t0)
+    x17 = (1/2)*x16
+    x18 = x17*x4
+    x19 = x17*x7
+
+    c0 = 16.0*(x11*(x6 + x8) - x13*(-x12*(-x6 - x8) + 2*x5))**2
+    c1 = 16.0*(x11*(-x14 - x15) - x13*(-2*u0 - x12*(x14 + x15)))**2
+    c2 = 16.0*(x11*(-x18 - x19) - x13*(-x12*(x18 + x19) - x16))**2
+    #i.e. for te, u0, to
+    return [c0, c1, c2 ]
+
+def TAP_planet_priority_error(time_now,t0_pspl,u0_pspl,tE_pspl,covariance):
+    """
+    This function calculates the priority for ranking
+    microlensing events based on the planet probability psi
+    as defined by Dominik 2009 and estimates the cost of
+    observations based on an empiric RMS estimate
+    obtained from a DANDIA reduction of K2C9 Sinistro
+    observations from 2016. It expects the overhead to be
+    60 seconds and also return the current Paczynski
+    light curve magnification.
+    """
+
+    usqr = u0_pspl**2 + ((time_now - t0_pspl) / tE_pspl)**2
+
+    dpsipdu = -8*(usqr+2)/(usqr*(usqr+4)**1.5)
+    dpsipdu += 4*(usqr**0.5*(usqr+4)**0.5+usqr+2)/(usqr+2+(usqr+4)**0.5)**2*1/(usqr+4)**0.5
+
+
+
+
+    dUdto = -(time_now - t0_pspl) / (tE_pspl ** 2 *usqr**0.5)
+    dUduo = u0_pspl/ usqr**0.5
+    dUdtE = -(time_now - t0_pspl) ** 2 / (tE_pspl ** 3 * usqr**0.5)
+
+    Jacob = np.zeros(len(covariance))
+    Jacob[0] = dpsipdu*dUdto
+    Jacob[1] = dpsipdu*dUduo
+    Jacob[2] = dpsipdu*dUdtE
+
+
+    error_psip = np.dot(Jacob.T,np.dot(covariance,Jacob))**0.5
+
+    return error_psip #/ (calculate_exptime_omega_sdss_i(mag) + 60.)
+
+def TAP_planet_priority(time_now,t0_pspl,u0_pspl,tE_pspl):
+    """
+    This function calculates the priority for ranking
+    microlensing events based on the planet probability psi
+    as defined by Dominik 2009 and estimates the cost of
+    observations based on an empiric RMS estimate
+    obtained from a DANDIA reduction of K2C9 Sinistro
+    observations from 2016. It expects the overhead to be
+    60 seconds and also return the current Paczynski
+    light curve magnification.
+    """
+    usqr = u0_pspl**2 + ((time_now - t0_pspl) / tE_pspl)**2
+    pspl_deno = (usqr * (usqr + 4.))**0.5
+    if pspl_deno < 1e-10:
+        pspl_deno = 10000.
+    psip = 4.0 / (pspl_deno) - 2.0 / (usqr + 2.0 + pspl_deno)
+
+    return psip
+
+def TAP_long_event_priority(t_now, t_last, t_E, t_E_base = 75.):
+    """
+    This function calculates priority of a long microlensing event.
+    If the event has a timescale equal to t_E_base, and was not
+    observed for t_obs_gap days, the priority should be close to 10.
+    If the event was not observed for more than 10 days,
+    the priority is boosted by 10.
+    If the fit was bad (indicated by t_E being a NaN), than
+    the priority drops to 0.
+    Inspired by Horn et al. 2009.
+
+    :param t_now: current JD
+    :param t_last: JD of the latest datapoint in any lightcurve
+                    assigned to the dataset
+    :param t_E: Einstein timescale of the event
+    :param t_E_base: cutoff point for long tE event
+
+    :return: priority of the long microlensing event
+    """
+
+    if (np.isnan(t_E)):
+        # t_E may hit the fit bounds. This means, the fit was
+        # wrong. In this case the event should not be observed
+        # and wait for a better estimate of the values.
+        psi = 0.
+    else:
+        t_obs_gap = 2.
+
+        # Events with t_E of t_E_base days will have priority 10.
+        psi = t_E / t_E_base
+
+        # If the event was not observed for t_obs_gap days the priority
+        # should rise.
+        delta_t = t_now - t_last
+        x = (delta_t / t_obs_gap) - t_obs_gap
+        psi *= 10. / (1. + np.exp(-x))
+
+        # The event priority should be boosted if it was not
+        # observed for more than 10 days and it is a long event.
+        if (delta_t > 10.):
+            psi *= 10.
+
+    return psi
+
+def TAP_long_event_priority_error(t_E, covariance, t_E_base = 75.):
+    """
+    This function calculates error of the priority
+    of a long microlensing event.
+
+    :param t_E: Einstein timescale of the event
+    :param covariance: covariance matrix
+    :param t_E_base: cutoff point for long tE event
+
+    :return: error of the priority of the long microlensing event.
+    """
+
+    if(np.isnan(t_E)):
+        err_psi = 0.
+    else:
+        # Simple derevative
+        err_t_E = np.sqrt(covariance[2,2])
+        err_psi = err_t_E / t_E_base
+
+    return err_psi
+
+def check_planet_priority(planet_priority, planet_priority_error, mag_baseline, mag_now):
+    '''
+    This function checks if the event status should be changed to priority stellar event.
+
+    :param planet_priority: value of the TAP_planet_priority for the event
+    :param planet_priority_error: error of the priority
+    :param mag_baseline: baseline magnitude of the event
+    :param mag_now: current magnitude of the event
+    '''
+    if (planet_priority>10) and (planet_priority/planet_priority_error>3)
+        and (mag_baseline-mag_now>2) and (mag_now<19)):
+        return True
+    else:
+        return False
+
+def check_long_priority(long_priority, long_priority_error,
+                        t_E, t_E_error, t_0, t_0_error,
+                        t_now,mag_baseline):
+    if (long_priority > 10.
+        and(long_priority / long_priority_error > 3.)
+        and (t_E / t_E_error > 5.) and (mag_baseline < 17.5)
+        and red_chi2 < 20.
+        and (((t_0 - t_now - (3. * (t_0_error + t_E_error))) / t_E) < 1.2)):
+        if(long_priority > 50.):
+            return 'priority'
+        else:
+            return 'regular'
+    else:
+        return None

--- a/mop/toolbox/TAP_priority.py
+++ b/mop/toolbox/TAP_priority.py
@@ -153,7 +153,7 @@ def check_planet_priority(planet_priority, planet_priority_error, mag_baseline, 
     '''
     This function checks if the event status should be changed to priority stellar event.
 
-    :param planet_priority: value of the TAP_planet_priority for the event
+    :param planet_priority: value of the TAP_priority for the event
     :param planet_priority_error: error of the priority
     :param mag_baseline: baseline magnitude of the event
     :param mag_now: current magnitude of the event
@@ -165,13 +165,22 @@ def check_planet_priority(planet_priority, planet_priority_error, mag_baseline, 
         return False
 
 def check_long_priority(long_priority, long_priority_error,
-                        t_E, t_E_error, t_0, t_0_error,
-                        t_now,mag_baseline):
+                        t_E, t_E_error, mag_baseline):
+    '''
+    This function checks if the event status should be changed to priority stellar event.
+
+    :param long_priority: value of the TAP_priority_longE for the event
+    :param long_priority_error: error of the priority
+    :param t_E: Einstein timescale of the best fitting model
+    :param t_E: uncertianity of the Einstein timescale of the best fitting model
+    :param red_chi2: chi2 over degrees of freedom of the best fitting model
+    :param mag_baseline: baseline magnitude of the event
+    '''
     if (long_priority > 10.
         and(long_priority / long_priority_error > 3.)
-        and (t_E / t_E_error > 5.) and (mag_baseline < 17.5)
-        and red_chi2 < 20.
-        and (((t_0 - t_now - (3. * (t_0_error + t_E_error))) / t_E) < 1.2)):
+        and (t_E / t_E_error > 3.) and (mag_baseline < 17.5)
+        and red_chi2 < 20.):
+        # and (((t_0 - t_now - (3. * (t_0_error + t_E_error))) / t_E) < 1.2)): # turning off events should be handled by Alive status
         if(long_priority > 50.):
             return 'priority'
         else:


### PR DESCRIPTION
This pull request is a response to issue 67. The long priority events will be turned off by checking their "Alive" status, but the long priority estimation and evaluation of targets had to be corrected.

I have moved TAP_priority estimation and handling to a different module, per Etienne's suggestion.