### PR TITLE
Fix classifier logic for TNS objects.

### DIFF
--- a/helm-chart/values-prod.yaml
+++ b/helm-chart/values-prod.yaml
@@ -45,7 +45,7 @@ postgresql:
 resources:
   requests:
     cpu: 500m
-    memory: 512Mi
+    memory: 768Mi
   limits:
     cpu: 2
     memory: 2Gi

--- a/mop/toolbox/classifier_tools.py
+++ b/mop/toolbox/classifier_tools.py
@@ -159,9 +159,9 @@ def check_known_variable(target, coord=None):
         if 'none' not in str(extra_params['TNS_class']).lower():
             extra_params['Classification'] = extra_params['TNS_class']
             extra_params['Category'] = extra_params['TNS_class']
-        else:
-            extra_params['Classification'] = 'Known transient'
-            extra_params['Category'] = 'Unclassified'
+        # else:
+        #     extra_params['Classification'] = 'Known transient'
+        #     extra_params['Category'] = 'Unclassified'
 
     target.save(extras=extra_params)
 


### PR DESCRIPTION
In toolbox/classifier_tools.py function check_known_variable was setting events with known TNS name but without TNS classification as "Known transient". Unfortunately, this resulted in Gaia Science Alerts not being considered as microlensing events, because all of them receive a TNS name at the time of publication. I commented on a section, where this happens and this should improve valid microlensing events detection by run_TAP.